### PR TITLE
version 0.3.0: BREAKING CHANGES

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,9 +36,9 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+    - name: Test with pytest and collect coverage
       run: |
-        pytest
+        pytest --cov .
     - name: Test with mypy
       run: |
         mypy -m dvplc

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,3 +42,7 @@ jobs:
     - name: Test with mypy
       run: |
         mypy -m dvplc
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "dvplc"
 description = "CLI app to convert Dava SmartDLC .dvpl files used in Wargaming.net's World of Tanks Bliz MMO game"
 readme = "README.md"
-version = "0.2"
+version = "0.3a1"
 authors = [{ name = "Jylpah", email = "jylpah@gmail.com" }]
 license = { text = "MIT License" }
 requires-python = ">=3.10"
@@ -17,6 +17,8 @@ dependencies = [
 	"aiofiles>=23.1.0",
 	"aioconsole>=0.6.1",
 	"pyutils @ git+https://github.com/Jylpah/pyutils.git@main-1.0",
+    "result>=0.15.0", 
+    "typer>=0.9.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "dvplc"
 description = "CLI app to convert Dava SmartDLC .dvpl files used in Wargaming.net's World of Tanks Bliz MMO game"
 readme = "README.md"
-version = "0.3a1"
+version = "0.3.0"
 authors = [{ name = "Jylpah", email = "jylpah@gmail.com" }]
 license = { text = "MIT License" }
 requires-python = ">=3.10"
@@ -26,7 +26,7 @@ dev = [
 	"build>=0.10.0",
 	"mypy>=1.2.0",
 	"pip-chill>=1.0.3",
-	"pytest",
+	"pytest>=7.4.3",
 	"pytest-asyncio",
 	"pytest-datafiles",
     "pytest-cov>=4.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,12 @@ reportGeneralTypeIssues = false
 # line-length = 120
 include = '\.pyi?$'
 
+[tool.coverage.run]
+omit= ['tests/*']
+
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "-v"
+addopts = "-v --cov=src"
 filterwarnings = [
 	'ignore:Inheritance class ThrottledClientSession from ClientSession is discouraged:DeprecationWarning',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
 	"pytest",
 	"pytest-asyncio",
 	"pytest-datafiles",
+    "pytest-cov>=4.1.0",
 	"pytest-mypy",
 	"types-aiofiles>=23.1.0.1",
 ]

--- a/src/dvplc/__init__.py
+++ b/src/dvplc/__init__.py
@@ -1,8 +1,12 @@
-from .dvplc import encode_dvpl as encode_dvpl, \
-					decode_dvpl as decode_dvpl, \
-					encode_dvpl_file as encode_dvpl_file, \
-					decode_dvpl_file as decode_dvpl_file, \
-					verify_dvpl_file as verify_dvpl_file, \
-					COMPRESSION as COMPRESSION, \
-					COMPRESSION_TYPE as COMPRESSION_TYPE
-__all__ = [ "dvplc" ]
+from .dvplc import (
+    encode_dvpl as encode_dvpl,
+    decode_dvpl as decode_dvpl,
+    encode_dvpl_file as encode_dvpl_file,
+    decode_dvpl_file as decode_dvpl_file,
+    verify_dvpl_file as verify_dvpl_file,
+    DEFAULT_COMPRESSION as DEFAULT_COMPRESSION,
+    COMPRESSION_TYPE as COMPRESSION_TYPE,
+    Compression as Compression,
+)
+
+__all__ = ["dvplc"]


### PR DESCRIPTION
- BREAKING CHANGE: `encode_dvpl()`, `decode_dvpl()` and  `verify_dvpl()` return `Result`, not `Tuple[Optional[bytes], str]`
- REFACTOR: CLI arg parsing with `Typer`
- REFACTOR: Use `Result` ... since it is cool
- More tests: `pytest`coverage 78%
